### PR TITLE
Repo - Build - CMake Windows and Visual Studio 2022

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 ###################
 build/
 submit/
-.vs/
 
 # OS generated files #
 ######################
@@ -13,3 +12,176 @@ submit/
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+
+
+
+#################
+# Visual Studio #
+#################
+.vs/
+*_i.c
+*_p.c
+*_h.h
+*.ilk
+*.meta
+*.obj
+*.iobj
+*.pch
+*.pdb
+*.ipdb
+*.pgc
+*.pgd
+*.rsp
+# but not Directory.Build.rsp, as it configures directory-level build defaults
+!Directory.Build.rsp
+*.sbr
+*.tlb
+*.tli
+*.tlh
+*.tmp
+*.tmp_proj
+*_wpftmp.csproj
+*.log
+*.tlog
+*.vspscc
+*.vssscc
+.builds
+*.pidb
+*.svclog
+*.scc
+
+# User-specific files
+*.rsuser
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Build artifacts
+Generated\ Files/
+BenchmarkDotNet.Artifacts/
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+[Ww][Ii][Nn]32/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+[Ll]ogs/
+
+# MSTest
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+# NUnit
+*.VisualState.xml
+TestResult.xml
+nunit-*.xml
+
+# .NET Core
+project.lock.json
+project.fragment.lock.json
+artifacts/
+
+# ASP.NET Scaffolding
+ScaffoldingReadMe.txt
+
+# Visual C++ cache files
+ipch/
+*.aps
+*.ncb
+*.opendb
+*.opensdf
+*.sdf
+*.cachefile
+*.VC.db
+*.VC.VC.opendb
+
+# Visual Studio profiler
+*.psess
+*.vsp
+*.vspx
+*.sap
+
+# Visual Studio Trace Files
+*.e2e
+
+# Visual Studio code coverage results
+*.coverage
+*.coveragexml
+
+# NuGet Packages
+*.nupkg
+# NuGet Symbol Packages
+*.snupkg
+# The packages folder can be ignored because of Package Restore
+**/[Pp]ackages/*
+# except build/, which is used as an MSBuild target.
+!**/[Pp]ackages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/[Pp]ackages/repositories.config
+# NuGet v3's project.json files produces more ignorable files
+*.nuget.props
+*.nuget.targets
+
+# Microsoft Azure Build Output
+csx/
+*.build.csdef
+
+# Microsoft Azure Emulator
+ecf/
+rcf/
+
+# Windows Store app package directories and files
+AppPackages/
+BundleArtifacts/
+Package.StoreAssociation.xml
+_pkginfo.txt
+*.appx
+*.appxbundle
+*.appxupload
+
+# Visual Studio cache files
+# files ending in .cache can be ignored
+*.[Cc]ache
+# but keep track of directories ending in .cache
+!?*.[Cc]ache/
+
+# RIA/Silverlight projects
+Generated_Code/
+
+# SQL Server files
+*.mdf
+*.ldf
+*.ndf
+
+# Microsoft Fakes
+FakesAssemblies/
+
+
+
+
+###########
+# Plugins #
+###########
+
+# DocProject is a documentation generator add-in
+DocProject/buildhelp/
+DocProject/Help/*.HxT
+DocProject/Help/*.HxC
+DocProject/Help/*.hhc
+DocProject/Help/*.hhk
+DocProject/Help/*.hhp
+DocProject/Help/Html2
+DocProject/Help/html
+
+# GhostDoc plugin setting file
+*.GhostDoc.xml
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 ###################
 build/
 submit/
+.vs/
 
 # OS generated files #
 ######################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_Declare(
     googletest
     URL https://github.com/google/googletest/archive/24a9e940d481f992ba852599c78bb2217362847b.zip
+    DOWNLOAD_EXTRACT_TIMESTAMP NEW
 )
 FetchContent_MakeAvailable(googletest)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,6 +14,29 @@
                 "CMAKE_C_COMPILER": "/usr/bin/clang",
                 "CMAKE_CXX_COMPILER": "/usr/bin/clang++",
                 "CMAKE_BUILD_TYPE": "Debug"
+            },
+
+            "cmakeExecutable": "/usr/local/bin/cmake",
+            "vendor": { "microsoft.com/VisualStudioSettings/CMake/1.0": { "hostOS": "macOS" } }
+        },
+        {
+            "name": "get-win-makefiles",
+            "displayName": "Generate Windows MakeFiles from CMakeLists.txt",
+            "description": "In folder: build/win-makefiles",
+
+            "binaryDir": "${sourceDir}/build/win-makefiles",
+            "installDir": "${sourceDir}/build/win-makefiles",
+
+            "cacheVariables": {
+                "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/win-makefiles",
+                "CMAKE_BUILD_TYPE": "Debug"
+            },
+
+            "cmakeExecutable": "C:/Program Files/CMake/bin/cmake",
+            "vendor": { "microsoft.com/VisualStudioSettings/CMake/1.0": { "hostOS": "Windows" } },
+            "architecture": {
+                "value": "x64",
+                "strategy": "external"
             }
         }
     ],
@@ -25,7 +48,20 @@
 
             "cleanFirst": true,
             "configurePreset": "get-mac-makefiles",
-            "configuration": "Debug"
+            "configuration": "Debug",
+
+            "vendor": { "microsoft.com/VisualStudioSettings/CMake/1.0": { "hostOS": "macOS" } }
+        },
+        {
+            "name": "get-win-exe",
+            "displayName": "Build Windows executable from compiling MakeFiles",
+            "description": "In folder: build/",
+
+            "cleanFirst": true,
+            "configurePreset": "get-win-makefiles",
+            "configuration": "Debug",
+
+            "vendor": { "microsoft.com/VisualStudioSettings/CMake/1.0": { "hostOS": "Windows" } }
         }
     ]
 }

--- a/csd-233-cpp.sln
+++ b/csd-233-cpp.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35825.156 d17.13
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "csd-233-cpp", "csd-233-cpp.vcxproj", "{479D7273-6494-469B-950F-F4AD2E73D621}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{479D7273-6494-469B-950F-F4AD2E73D621}.Debug|x64.ActiveCfg = Debug|x64
+		{479D7273-6494-469B-950F-F4AD2E73D621}.Debug|x64.Build.0 = Debug|x64
+		{479D7273-6494-469B-950F-F4AD2E73D621}.Debug|x86.ActiveCfg = Debug|Win32
+		{479D7273-6494-469B-950F-F4AD2E73D621}.Debug|x86.Build.0 = Debug|Win32
+		{479D7273-6494-469B-950F-F4AD2E73D621}.Release|x64.ActiveCfg = Release|x64
+		{479D7273-6494-469B-950F-F4AD2E73D621}.Release|x64.Build.0 = Release|x64
+		{479D7273-6494-469B-950F-F4AD2E73D621}.Release|x86.ActiveCfg = Release|Win32
+		{479D7273-6494-469B-950F-F4AD2E73D621}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0A317FC6-CC82-4AEF-B4F9-DB05EE5A1A2B}
+	EndGlobalSection
+EndGlobal

--- a/csd-233-cpp.vcxproj
+++ b/csd-233-cpp.vcxproj
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{479d7273-6494-469b-950f-f4ad2e73d621}</ProjectGuid>
+    <RootNamespace>csd233cpp</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ExecutablePath>$(ProgramData)\opencv\build\x64\vc16\bin;$(ExecutablePath)</ExecutablePath>
+    <ExternalIncludePath>$(ProgramData)\opencv\build\include\opencv2;$(ExternalIncludePath)</ExternalIncludePath>
+    <ReferencePath>$(ProgramData)\opencv\build\x64\vc16\lib;$(ReferencePath)</ReferencePath>
+    <LibraryPath>$(ProgramData)\opencv\build\x64\vc16\lib;$(LibraryPath)</LibraryPath>
+    <OutDir>$(SolutionDir)build\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>build\$(ShortProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ExecutablePath>$(ProgramData)\opencv\build\x64\vc16\bin;$(ExecutablePath)</ExecutablePath>
+    <ExternalIncludePath>$(ProgramData)\opencv\build\include\opencv2;$(ExternalIncludePath)</ExternalIncludePath>
+    <ReferencePath>$(ProgramData)\opencv\build\x64\vc16\lib;$(ReferencePath)</ReferencePath>
+    <LibraryPath>$(ProgramData)\opencv\build\x64\vc16\lib;$(LibraryPath)</LibraryPath>
+    <OutDir>$(SolutionDir)build\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>build\$(ShortProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>opencv_world4110d.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>opencv_world4110d.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/csd-233-cpp.vcxproj
+++ b/csd-233-cpp.vcxproj
@@ -18,6 +18,9 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\5_projOptimalClassTime\main.cpp" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>17.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>

--- a/csd-233-cpp.vcxproj.filters
+++ b/csd-233-cpp.vcxproj.filters
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+</Project>

--- a/csd-233-cpp.vcxproj.filters
+++ b/csd-233-cpp.vcxproj.filters
@@ -14,4 +14,9 @@
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
   </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\5_projOptimalClassTime\main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
 </Project>

--- a/src/5_projOptimalClassTime/main.cpp
+++ b/src/5_projOptimalClassTime/main.cpp
@@ -129,8 +129,9 @@ static const enginegoto getschedules(SchedulePoll* out) {
             case ::part2:
             case ::quit:
                 if (delimbuffer == '\0' || isspace(delimbuffer)) {
+                    enginegoto enginenext = (enginegoto) *userinput;
                     delete[] userinput;
-                    return (enginegoto) (*userinput);
+                    return enginenext;
                 }
             default:
                 int status = out->import(userinput);

--- a/src/5_projOptimalClassTime/schedulePoll.cpp
+++ b/src/5_projOptimalClassTime/schedulePoll.cpp
@@ -254,7 +254,7 @@ int SchedulePoll::import(char const* schedulefile_) {
     if (studentend == NOTFOUND)
         studentend = std::strlen(schedulefile_);
 
-    char* student = new char[studentend - studentpos];
+    char* student = new char[1 + studentend - studentpos];
     student[studentend - studentpos] = '\0';
     std::copy((schedulefile_ + studentpos), (schedulefile_ + studentend), student);
 

--- a/src/5_projOptimalClassTime/schedulePoll.cpp
+++ b/src/5_projOptimalClassTime/schedulePoll.cpp
@@ -308,6 +308,8 @@ int SchedulePoll::import(char const* schedulefile_) {
 
         // GARBAGE COLLECTION
         delete[] jour;
+        for (int i = 0; i < hourcount; i++)
+            delete[] hours[i];
         delete[] hours;
     }
 

--- a/src/5_projOptimalClassTime/schedulePoll.cpp
+++ b/src/5_projOptimalClassTime/schedulePoll.cpp
@@ -88,7 +88,8 @@ node::~node() {
  */
 void node::add(char const* student_) {
     int len = std::strlen(student_);
-    char* name = new char[len];
+    char* name = new char[len + 1];
+    name[len] = '\0';
     if (__count == __mem) __alloc();
     std::copy(student_, (student_ + len), name);
     __students[__count++] = name;


### PR DESCRIPTION
### Add CMake presets for Windows and Visual Studio 2022
- **build: add CMake preset for Windows**
- **build: add visual studio solution**

### Fix - Module 5 - Project - Optimal Class Time
_Compiling with clang++ in VSCode on MacOS, these problems were not discovered, and the program even behaved as intended. But on Visual Studio 2022's C++ compiler, heap corruptions and improper memory accesses were discovered._

- **fix: in SchedulePoll::import(), add +1 to temporary char ptr size to account for null terminator**
- **fix: in SchedulePoll::import(), add missing delete[]**
- **fix: in getschedules(), move deletion to after it's done being used**
- **fix: in node.add(), insert missing null terminator char**
